### PR TITLE
Encrypt the exported data

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Export googleOTP app to anOTP
 ## This is a basic python3 script used to export a json file from a QR code generated from Google Authenticator App
 ### Pre-requirements
 * Protoc must be installed (https://developers.google.com/protocol-buffers/docs/pythontutorial#compiling-your-protocol-buffers)
-* Python3
+* Python 3
 
 ## Protobuf/protoc parser
 ### Below and example of parsing base64 to protobuf format, used to reverse engineering (input.txt with 1 base64 entry URLdecoded)
@@ -33,26 +33,23 @@ $ base64 -D input.txt |protoc --decode_raw
 
 ### How to
 1. `git clone https://github.com/wmdebrito/googleOTP-to-andOTP.git`
-2. Go to export account on Google App Authenticator
-3. Scan the QRCode, for example using: https://qrcodescan.in/ (Tip, it is hard get it right when you have too many entries. The QRCodes the app generates are hard the read with Webcam. You can export it is smaller batches 5-8 entries at time or Use another phone that have focus adjustment)
-4. copy the scanned string `(otpauth-migration://offline?data=CiEKEUpSkaZJ...)` to a file (`input.txt` for example)
+2. Setup a virtualenv:
+
+   1. `python3 -m virtualenv venv`
+   2. `source venv/bin/activate`
+   3. Install requirements: `pip install -r requirements.txt`
+3. Go to export account on Google App Authenticator
+4. Scan the QRCode, for example using: https://qrcodescan.in/ (Tip: it is hard to get it right when you have too many entries. The QRCodes the app generates are hard to read with a webcam. You can export it in smaller batches 5-8 entries at a time or use another phone that has focus adjustment)
+5. Copy the scanned string `(otpauth-migration://offline?data=CiEKEUpSkaZJ...)` to a file (`input.txt` for example)
    - if you have too many accounts, more than 1 QRCode will be generated, put the string scanned in each line of the file.
-5. save the `input.txt` file
-6. run `rm GAuthPayload_pb2.py && protoc --python_out=. GAuthPayload.proto`
-7. run the script `python3 toAndOTP.py <input file> <output file>.json`
-   - example `$ python3 toAndOTP.py ~/input.txt ~/exported.json`
-   
-Also https://github.com/jay-aye-see-kay suggested the steps below in case the above fails:
- - set up a virtual env
- 
-`python 3 -m venv venv`
+6. Save the `input.txt` file
+7. Run `rm GAuthPayload_pb2.py && protoc --python_out=. GAuthPayload.proto`
+8. Run the script `python3 toAndOTP.py <input file> <output file>.bin`
+   - Example: `$ python3 toAndOTP.py ~/input.txt ~/exported.bin`
 
-`source venv/bin/activate`
+   The script will prompt for a password that is used to encrypt the exported data.
+   The given password will be used in andOTP to decrypt the exported data.
 
- - install python protobuf package (you need an OS install of protobuf too, as mentioned in the pre-requirements)
- 
-`pip install protobuf`
+8. Now transfer the exported file to your phone and restore backup (encrypted).
 
-`python toAndOTP.py <input file> <output file>.json`
-
-8. now transfer the exported file to your phone and restore backup (plain text).**IMPORTANT** Make a BACKUP of your andOTP accounts before importing the exported file
+   **IMPORTANT**: Make a BACKUP of your andOTP accounts before importing the exported file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+protobuf==3.13.0
+cryptography==3.2.1

--- a/toAndOTP.py
+++ b/toAndOTP.py
@@ -1,15 +1,21 @@
 #! /usr/bin/python3
 
 from GAuthPayload_pb2 import GAuthPayload
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 import sys
+import secrets
+import getpass
 import urllib.parse
 import base64
 from pprint import pprint
 import json
 
+
 def decode(b64Payload):
     payload = urllib.parse.unquote(b64Payload)
-    payload = payload.replace('otpauth-migration://offline?data=','')
+    payload = payload.replace('otpauth-migration://offline?data=', '')
     payload = base64.b64decode(payload)
 
     gAuthPayload = GAuthPayload()
@@ -17,18 +23,21 @@ def decode(b64Payload):
 
     return exportToAndOTP(gAuthPayload)
 
+
 def exportToAndOTP(gAuthPayload):
     andOtpValues = []
     for entry in gAuthPayload.payload:
         andOtpItem = {
-               "algorithm": "SHA1" if (entry.algorithm == 1) else "ERROR", #Google supports on SHA1
-               "digits": "6" if (entry.digits == 1)  else str(entry.digits), #only supports 6
-               "type": "TOTP" if (entry.type == 2)  else "HOTP",
-               "secret": base64.b32encode(entry.secret).decode("utf8").replace("=",""),
-               "label": entry.name,
-               "issuer": entry.issuer,
-               "thumbnail": entry.issuer
-            }
+            # Google supports on SHA1
+            "algorithm": "SHA1" if (entry.algorithm == 1) else "ERROR",
+            # only supports 6
+            "digits": "6" if (entry.digits == 1) else str(entry.digits),
+            "type": "TOTP" if (entry.type == 2) else "HOTP",
+            "secret": base64.b32encode(entry.secret).decode("utf8").replace("=", ""),
+            "label": entry.name,
+            "issuer": entry.issuer,
+            "thumbnail": entry.issuer
+        }
 
         if entry.counter:
             andOtpItem["counter"] = entry.counter
@@ -37,12 +46,55 @@ def exportToAndOTP(gAuthPayload):
 
     return andOtpValues
 
+
+def encrypt(andOptData, password):
+    # Encrypt the created andOTP-formatted data
+    # Specs: https://github.com/andOTP/andOTP/wiki/Backup-encryption
+
+    # Create JSON from the data
+    json_bytes = json.dumps(andOptData).encode("utf-8")
+
+    # Random 12-byte (96 bit) IV (nonce)
+    nonce = secrets.token_bytes(12)
+
+    # 256 bit key
+    # PBKDF2 with HMAC-SHA1
+    # Random iterations, random 12 byte salt
+    # As of 2020-10-29 andOTP uses 140000-160000 iterations, so do we
+    iterations = 140000 + secrets.randbelow(20001)
+    salt = secrets.token_bytes(12)
+
+    # Derive the key used to encrypt the JSON data
+    kdf = PBKDF2HMAC(algorithm=hashes.SHA1(), length=32,
+                     salt=salt, iterations=iterations)
+    key = kdf.derive(password.encode("utf-8"))
+
+    # Encrypt the JSON data
+    # AESGCM, no padding
+    a = AESGCM(key)
+    encrypted = a.encrypt(nonce, json_bytes, None)
+
+    # Format: [PBKDF2 iterations (4 bytes, Int32)] + [PBKDF2 salt (12 bytes)] + [AES IV (12 bytes)] + [Encrypted payload]
+    # Iteration int32 is big endian
+    iter_bytes = iterations.to_bytes(length=4, byteorder="big")
+    encrypted_data = iter_bytes + salt + nonce + encrypted
+
+    return encrypted_data
+
+
 inputFile = "input.txt" if (len(sys.argv) < 2) else sys.argv[1]
 with open(inputFile, "r") as inputValues:
-    print("Reading file:"+ inputFile)
+    print("Reading file: " + inputFile)
     fullResult = []
     for line in inputValues:
-         fullResult = fullResult + decode(line)
-    fileExported = "exported.json" if (len(sys.argv) < 3) else sys.argv[2]
-    json.dump(fullResult, open(fileExported, "w"))
-    print("Exported file:"+ fileExported)
+        fullResult = fullResult + decode(line)
+    fileExported = "exported.bin" if (len(sys.argv) < 3) else sys.argv[2]
+
+# Get password from the user
+password = getpass.getpass("Encryption password: ")
+encrypted_data = encrypt(fullResult, password)
+
+with open(fileExported, "wb") as f:
+    f.write(encrypted_data)
+
+print("Exported file (encrypted): " + fileExported)


### PR DESCRIPTION
This PR adds support for encrypting the created JSON using the backup encryption specs specified here: https://github.com/andOTP/andOTP/wiki/Backup-encryption
The user is prompted for an encryption password when running the script. The encrypted file can then be restored using the "Restore (encrypted)" option in andOTP.

As the encryption functionality needs the `cryptography` module, I added a `requirements.txt` file and removed the non-virtualenv instructions, as the usage of virtualenv is preferred (at least in this case because of the required modules).

Note that the current example `input.txt` doesn't work for importing, because the HOTP entry needs a counter value (andOTP shows an error regarding "no entries", logcat reveals that the counter value is missing).

I was able to migrate my own accounts from GAuth as encrypted backup using the modifications made in this PR.